### PR TITLE
#159082371 Configure Authors Haven to use PostgreSQL as DB En…

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,5 +392,11 @@ No additional parameters required
 `GET /api/tags`
 
 
+----------
+### Running the Appllication
 
+`python3 manage.py runserver --settings=authors.settings.dev`
 
+### Running tests
+
+`python3 manage.py test --settings=authors.settings.test`

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -18,10 +18,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '7pgozr2jn7zs_o%i8id6=rddie!*0f0qy3$oy$(8231i^4*@u3'
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
 ALLOWED_HOSTS = []
+
+# automaticall append slashes
+APPEND_SLASH = True
 
 # Application definition
 
@@ -53,7 +53,7 @@ NOSE_ARGS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    # 'corsheaders.middleware.CorsMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -80,16 +80,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'authors.wsgi.application'
-
-# Database
-# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
 
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators

--- a/authors/settings/dev.py
+++ b/authors/settings/dev.py
@@ -1,0 +1,19 @@
+import os
+from authors.settings.base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': os.getenv('DB_NAME'),
+        'USER': os.getenv('DB_USER'),
+        'PASSWORD': os.getenv('DB_PASSWORD'),
+        'HOST': 'localhost',
+        'PORT': '',
+    }
+}

--- a/authors/settings/test.py
+++ b/authors/settings/test.py
@@ -1,0 +1,15 @@
+import os
+from authors.settings.base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,9 @@ isort==4.3.4
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
 nose==1.3.7
-pycodestyle==2.4.0
+psycopg2-binary==2.7.5
 PyJWT==1.6.4
 pylint==2.0.1
 pytz==2018.5
 six==1.11.0
-typed-ast==1.1.0
 wrapt==1.10.11


### PR DESCRIPTION
### What does this PR do?
- Configures Authors Haven to use PostgreSQL as DB Engine

### Description of Task to be completed?
- PostgreSQL is Open Source, fully featured and optimized for production ready environments as compared to SQLite that comes as default with the Authors Haven application

### How should this be manually tested?
- Running the server
- 'python3 manage.py runserver --settings=authors.settings.dev'

- Running tests
- 'python3 manage.py test --settings=authors.settings.test'

### Any background context you want to provide?
- I created a settings module that contains application settings for the testing and development environments.
- I installed 'psycopg2-binary==2.7.5' which connects Authors Haven to PostgresSQL

### What are the relevant pivotal tracker stories?
- [#159082371](https://www.pivotaltracker.com/story/show/159082371)
