### PR TITLE
#159082375 Users should be able to reset password via email

### DIFF
--- a/authors/apps/authentication/tests/test_password_reset.py
+++ b/authors/apps/authentication/tests/test_password_reset.py
@@ -1,0 +1,79 @@
+from django.test import Client, TestCase
+import json
+import jwt
+import os
+from datetime import datetime, timedelta
+
+from ..models import User
+from django.conf import settings
+
+
+class TestPasswordReset(TestCase):
+    def setUp(self):
+        self.email = "testuseremail@email.com"
+        self.username = 'testing12'
+        self.password = 'testuserpass'
+
+        self.user_that_lost_password = {
+            'user': {
+                'email': self.email,
+                "callbackurl": "https://www.youtube.com/"
+            }
+        }
+
+        self.new_password_data = {
+            'user': {
+                'new_password': "new_Password@2018"
+            }
+        }
+
+        self.user = User.objects.create_user(
+            self.username, self.email, self.password)
+
+        self.test_client = Client()
+
+    def test_password_reset_endpoint(self):
+        """
+        Test to test that the password reset endpoint is hit successfully
+        """
+        response = self.test_client.post(
+            "/api/user/reset_password/", data=json.dumps(self.user_that_lost_password),
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_password_update_endpoint(self):
+        """
+        Test to test that the update password endpoint is hit successfully
+        """
+        response = self.test_client.post(
+            "/api/user/new_password/{}/".format(self.token), data=json.dumps(self.new_password_data),
+            content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_password_update_endpoint_with_invalid_token(self):
+        """
+        """
+        response = self.test_client.post(
+            "/api/user/new_password/{}/".format("self.token123"), data=json.dumps(self.new_password_data),
+            content_type='application/json')
+        print(response.json())
+        self.assertEqual(response.status_code, 400)
+
+    def generate_token(self):
+        dt = datetime.now() + timedelta(minutes=30)
+
+        token = jwt.encode({
+            'username': self.username,
+            'email': self.email,
+            'exp': int(dt.strftime('%s')),
+            'call_back_url': os.getenv('CALL_BACK_URL')
+        }, settings.SECRET_KEY, algorithm='HS256')
+
+        return token.decode('utf-8')
+
+    @property
+    def token(self):
+        """
+        Allows us to get a user's token by calling `user.token`
+        """
+        return self.generate_token()

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 
 from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView,
-    GoogleSocialAuthAPIView, FacebookSocialAuthAPIView, VerifyAPIView
+    GoogleSocialAuthAPIView, FacebookSocialAuthAPIView, VerifyAPIView,
+    ResetPasswordAPIView, UpdatePasswordAPIView
 )
 
 urlpatterns = [
@@ -12,4 +13,6 @@ urlpatterns = [
     path('auth/google/', GoogleSocialAuthAPIView.as_view()),
     path('auth/facebook/', FacebookSocialAuthAPIView.as_view()),
     path('activate/<str:token>', VerifyAPIView.as_view()),
+    path('user/reset_password/', ResetPasswordAPIView.as_view()),
+    path('user/new_password/<str:token>/', UpdatePasswordAPIView.as_view())
 ]

--- a/authors/apps/email/email.py
+++ b/authors/apps/email/email.py
@@ -36,7 +36,7 @@ class TokenGenerator:
         """
         try:
             return jwt.decode(token, settings.SECRET_KEY, algorithm='HS256')
-        except Exception:
+        except Exception as e:
             return "invalid token"
 
 

--- a/authors/apps/email/templates/reset_password.html
+++ b/authors/apps/email/templates/reset_password.html
@@ -1,0 +1,29 @@
+<div style="padding:0;margin:0 auto;width:100%!important;
+font-family:Helvetica,Arial,sans-serif">
+    <table style="background-color:#edf0f3;table-layout:fixed" align="center" cellspacing="0" cellpadding="0" width="100%" border="0" bgcolor="#EDF0F3">
+        <tbody> 
+            <tr>
+                <td align="center" style="font-weight: bold;font-size: 20px;background-color:#28c2ec;padding:12px;border-bottom:1px solid #ececec">
+                    Hi {{ username }}
+                </td>
+            </tr>
+            <tr align="center">
+                <td style="padding:12px;background: #F6F8FA">You recently requested to reset your password for your account on Authors Haven.<br/>
+                    Please use the button below to reset to it<br/><br/><br/>
+                    <a href="{{callbackurl}}?token={{token}}" style="background:#2876ec;color:#edf0f3;text-decoration: none;padding: 10px;border-radius:  6px;">Reset Password</a>
+                    <br/><br/><br/>
+                    If you didn't request a password reset, please ignore this email or contact support at haven.authors@gmail.com
+                </td>
+            </tr>
+            <tr align="center" style="font-weight:500;font-size:13px;text-align: center;">
+                    <td style="padding:15px;">
+                    </td>
+                </tr>
+                <tr align="center" style="font-size:13px;text-align: center;">
+                    <td style="padding-top:20px;border-top:2px solid gray;padding:10px 0">
+                        &copy; {{ copyright_year }} Authors Haven All rights reserved
+                    </td>
+                </tr>
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
#### What does this PR do?
- Send users emails to reset their password
#### Description of Task to be completed?
- GIVEN a user forgets their password
- WHEN they request for a reset
- THEN they receive an email with a reset link to the application.
#### How should this be manually tested?
- Request for a password reset using the endpoint `/api/user/reset_password/`
#### Any background context you want to provide?
- Password reset functionality is missing in our application. Its invaluable in instances where our users forget their login credentials.
#### What are the relevant pivotal tracker stories?
[#159082375](https://www.pivotaltracker.com/story/show/159082375)
#### Screenshots
<img width="1119" alt="screen shot 2018-08-07 at 19 30 06" src="https://user-images.githubusercontent.com/25790450/43789333-5ee6b5e4-9a78-11e8-969c-9a21319d063a.png">
