### PR TITLE
#159082381 Add average rating output on user rating output

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -14,7 +14,6 @@ class ArticlesJSONRenderer(JSONRenderer):
         errors = data.get('errors', None)
 
         if errors is not None:
-            pass
             # As mentioned about, we will let the default JSONRenderer handle
             # rendering errors.
             return super(ArticlesJSONRenderer, self).render(data)
@@ -36,7 +35,6 @@ class CommentJSONRenderer(JSONRenderer):
         errors = data.get('errors', None)
 
         if errors is not None:
-            pass
             # As mentioned about, we will let the default JSONRenderer handle
             # rendering errors.
             return super(CommentJSONRenderer, self).render(data)
@@ -44,4 +42,25 @@ class CommentJSONRenderer(JSONRenderer):
         # Finally, we can render our data under the "user" namespace.
         return json.dumps({
             'comment': data
+        })
+
+
+class RatingJSONRenderer(JSONRenderer):
+    charset = 'utf-8'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        # If the view throws an error (such as the user can't be authenticated
+        # or something similar), `data` will contain an `errors` key. We want
+        # the default JSONRenderer to handle rendering errors, so we need to
+        # check for this case.
+        errors = data.get('errors', None)
+
+        if errors is not None:
+            # As mentioned about, we will let the default JSONRenderer handle
+            # rendering errors.
+            return super(RatingJSONRenderer, self).render(data)
+
+        # Finally, we can render our data under the "user" namespace.
+        return json.dumps({
+            'Rating': data
         })

--- a/authors/apps/articles/tests/tests_views.py
+++ b/authors/apps/articles/tests/tests_views.py
@@ -33,21 +33,21 @@ class BaseTest(TestCase):
         }
 
         self.rating_to_create = {
-            "article": {
+            "Rating": {
                 "rating": 1,
                 "review": "the service was really great. I recomend you go there."
             }
         }
 
         self.rating_lower_than_1 = {
-            "article": {
+            "Rating": {
                 "rating": 0,
                 "review": "the service was really great. I recomend you go there."
             }
         }
 
         self.rating_greater_than_5 = {
-            "article": {
+            "Rating": {
                 "rating": 6,
                 "review": "the service was really great. I recomend you go there."
             }
@@ -171,11 +171,11 @@ class TestArticleRating(BaseTest):
         headers = {'HTTP_AUTHORIZATION': 'Token ' + token}
 
         response = self.test_client.post(
-            "/api/articles/rate/1", **headers,
+            "/api/articles/1/rating/", **headers,
             data=json.dumps(self.rating_to_create), content_type='application/json')
         self.assertEqual(response.status_code, 201)
         self.assertEqual(
-            response.json()['article']['message'], 'Article rated successfully.')
+            response.json()['Rating']['message'], 'Article rated successfully.')
 
     def test_rating_lower_than_1(self):
         """ test if a user can make rating level less than one """
@@ -189,7 +189,7 @@ class TestArticleRating(BaseTest):
         headers = {'HTTP_AUTHORIZATION': 'Token ' + token}
 
         response = self.test_client.post(
-            "/api/articles/rate/1", **headers,
+            "/api/articles/1/rating/", **headers,
             data=json.dumps(self.rating_lower_than_1), content_type='application/json')
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -207,7 +207,7 @@ class TestArticleRating(BaseTest):
         headers = {'HTTP_AUTHORIZATION': 'Token ' + token}
 
         response = self.test_client.post(
-            "/api/articles/rate/1", **headers,
+            "/api/articles/1/rating/", **headers,
             data=json.dumps(self.rating_greater_than_5), content_type='application/json')
         self.assertEqual(response.status_code, 400)
         self.assertEqual(
@@ -225,11 +225,11 @@ class TestArticleRating(BaseTest):
         headers = {'HTTP_AUTHORIZATION': 'Token ' + token}
 
         self.test_client.post(
-            "/api/articles/rate/1", **headers,
+            "/api/articles/1/rating/", **headers,
             data=json.dumps(self.rating_to_create), content_type='application/json')
 
         response2 = self.test_client.post(
-            "/api/articles/rate/1", **headers,
+            "/api/articles/1/rating/", **headers,
             data=json.dumps(self.rating_to_create), content_type='application/json')
         self.assertEqual(response2.status_code, 400)
         self.assertEqual(
@@ -247,7 +247,7 @@ class TestArticleRating(BaseTest):
         headers = {'HTTP_AUTHORIZATION': 'Token ' + token}
 
         response = self.test_client.post(
-            "/api/articles/rate/1", **headers,
+            "/api/articles/1/rating/", **headers,
             data=json.dumps(self.rating_to_create), content_type='application/json')
         self.assertEqual(response.status_code, 400)
         self.assertEqual(

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -6,6 +6,6 @@ from .views import (
 
 urlpatterns = [
     path('articles/', CreateArticleAPIView.as_view()),
-    path('articles/rate/<int:article_id>', RateArticleAPIView.as_view()),
     path('articles/<int:article_id>/comment/', CommentArticleAPIView.as_view()),
+    path('articles/<int:article_id>/rating/', RateArticleAPIView.as_view()),
 ]


### PR DESCRIPTION
### What does this PR do?
- Returns average rating on an article
- Returns all the data of the rating that has just been created

### Description of Task to be completed?
- A user is able to rate an article.

### How should this be manually tested?
- Create a rating request in the format shown below.
```
{
    "Rating": {
		"rating": 4,
		"review": "The service was great"
    }
}
```
- Output should be shown as in the example below
```
{
    "Rating": {
        "rating": "4",
        "review": "The service was great",
        "article_id": 6,
        "user_id": 1,
        "message": "Article rated successfully.",
        "average_rating": 3.8620689655172415
    }
}
```
- Send it to the API endpoint `/api/articles/<int: article_id>/rating/`
- Note: review can contain one insight on the article but it is not a must to add it.

### Any background context you want to provide?
- I modified the renderer class to return rating
- Changed some lines of code in tests to suit all changes made
- Calculated average rating on an article
### What are the relevant pivotal tracker stories?
- [#159082381](https://www.pivotaltracker.com/story/show/159082381)