### PR TITLE
#59685390 Fix verify account email link not clickable

### DIFF
--- a/authors/apps/authentication/tests/test_views.py
+++ b/authors/apps/authentication/tests/test_views.py
@@ -221,7 +221,7 @@ class TestRegistration(BaseTest):
         response = self.user_registered
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.json()[
-                         'user']['message'], 'You were succesfull registered! Please check ' +
+                         'user']['message'], 'You were succesfully registered! Please check ' +
                          self.user_to_register["user"]["email"] + ' for a verification link.')
 
     def test_user_can_duplicate_registration(self):

--- a/authors/apps/email/templates/verify_email.html
+++ b/authors/apps/email/templates/verify_email.html
@@ -1,30 +1,47 @@
 <div style="padding:0;margin:0 auto;width:100%!important;
 font-family:Helvetica,Arial,sans-serif">
-    <table style="background-color:#edf0f3;table-layout:fixed" align="center" cellspacing="0" cellpadding="0" width="100%" border="0" bgcolor="#EDF0F3">
-        <tbody> 
+    <table style="background-color:#edf0f3;table-layout:fixed" align="center" cellspacing="0" cellpadding="0" width="100%" border="0"
+        bgcolor="#EDF0F3">
+        <tbody>
             <tr>
                 <td align="center" style="font-weight: bold;font-size: 20px;background-color:#28c2ec;padding:12px;border-bottom:1px solid #ececec">
                     Hi {{ username }}
                 </td>
             </tr>
             <tr align="center">
-                <td style="padding:12px;background: #F6F8FA">You have signed up for an account on Authors Haven.<br/>
-                    Please use the link below to finish signup<br/><br/><br/>
-                    <a href="{{ domain }}/api/activate/{{ token }}" style="background:#2876ec;color:#edf0f3;text-decoration: none;padding: 10px;border-radius:  6px;">Click here to verify email</a>
-                    <br/><br/><br/>
-                    Kindly ignore this email if you did not create the account
+                <td style="padding:12px;background: #F6F8FA">
+                    <div>
+                        <p>You have signed up for an account on Authors Haven.
+                            <br/> Please use the link below to finish signup.
+                        </p>
+                        <br/>
+                        <a href="{{ domain }}/api/activate/{{ token }}" style="background:#2876ec;color:#edf0f3;text-decoration: none;padding: 10px;border-radius:  6px;">Click here to verify email</a>
+                        <br/>
+                        <br/>
+                        <p>OR
+                            <br/>
+                            <br/>Copy and paste this link in your browser
+                            <br/>
+                            <br/>
+                            <a style="color:#2876ec;"> {{ domain }}/api/activate/{{ token }}</a>
+                        </p>
+                        <p>
+                            <strong>Kindly ignore this email if you did not create the account.</strong>
+                        </p>
+                        <br/>
+                    </div>
                 </td>
             </tr>
             <tr align="center" style="font-weight:500;font-size:13px;text-align: center;">
-                    <td style="padding:15px;">
-                        This message was automatically sent to your email upon registering at Authors Haven.
-                    </td>
-                </tr>
-                <tr align="center" style="font-size:13px;text-align: center;">
-                    <td style="padding-top:20px;border-top:2px solid gray;padding:10px 0">
-                        &copy; {{ copyright_year }} Authors Haven All rights reserved
-                    </td>
-                </tr>
+                <td style="padding:15px;">
+                    This message was automatically sent to your email upon registering at Authors Haven.
+                </td>
+            </tr>
+            <tr align="center" style="font-size:13px;text-align: center;">
+                <td style="padding-top:20px;border-top:2px solid gray;padding:10px 0">
+                    &copy; {{ copyright_year }} Authors Haven All rights reserved
+                </td>
+            </tr>
         </tbody>
     </table>
 </div>


### PR DESCRIPTION
### What does this PR do?
- allows users to copy and paste their verification links

### Description of Task to be completed?
- If the link is unclickable, users can copy and paste it into the browser.

### How should this be manually tested?
- Verification email sent now contains the link to copy

### Any background context you want to provide?
- Since Gmail can strip the `href="#"` attribute out of the anchor tag, I included the `reset` link in the in the email body.

### What are the relevant pivotal tracker stories?
- [#159685390](https://www.pivotaltracker.com/story/show/159685390)

### Screenshots
<img width="1085" alt="screen shot 2018-08-10 at 11 22 45" src="https://user-images.githubusercontent.com/21138053/43947084-c83b1670-9c8f-11e8-9aa7-e750e610a0d0.png">
